### PR TITLE
Update vars.sh

### DIFF
--- a/vars.sh
+++ b/vars.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-export JRE_URL=http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/jre-8u181-linux-x64.tar.gz
+export JRE_URL=https://download.oracle.com/otn-pub/java/jdk/8u201-b09/42970487e3af4f5aa5bca3f542482c60/jre-8u201-linux-x64.tar.gz
 export RUNDECK_DIST_URL="http://dl.bintray.com/rundeck/rundeck-maven/"
 export RUNDECK_WAR="rundeck-${RUNDECK_VERSION}.war"


### PR DESCRIPTION
updating JRE_URL to https://download.oracle.com/otn-pub/java/jdk/8u201-b09/42970487e3af4f5aa5bca3f542482c60/jre-8u201-linux-x64.tar.gz, which is compatible with the wget command in bin/supply